### PR TITLE
Add generators for tasks and workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 * Initial implementation of this package.
+* Added workflows and tasks generators.
 * Added this changelog.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ You can find all details on [Zenaton's website](https://zenaton.com/documentatio
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Getting started](#getting-started)
   - [Installation](#installation)
     - [Install the Zenaton Agent](#install-the-zenaton-agent)
     - [Install the Laravel package](#install-the-laravel-package)
   - [Quick start](#quick-start)
-    - [Client Initialization](#client-initialization)
     - [Executing a background job](#executing-a-background-job)
   - [Orchestrating background jobs](#orchestrating-background-jobs)
     - [Using workflows](#using-workflows)
@@ -98,7 +98,15 @@ php artisan vendor:publish --tag=zenaton-config
 
 A background job in Zenaton is a class implementing the `Zenaton\Interfaces\TaskInterface` interface.
 
-Let's start by implementing a first task printing something, and returning a value:
+Let's start by implementing a first task printing something, and returning a value.
+You can generate tasks using the `zenaton:make:task` artisan command:
+
+```sh
+php artisan zenaton:make:task HelloWorldTask
+```
+
+Open the `app/Zenaton/Tasks/HelloWorldTask.php` file that was generated for you and
+implement the `::handle()` method as the following:
 
 ```php
 namespace App\Zenaton\Tasks;
@@ -149,7 +157,14 @@ Otherwise, we won't do anything else.
 One important thing to remember is that your workflow implementation **must** be idempotent.
 You can read more about that in our [documentation](https://zenaton.com/documentation/php/workflow-basics/#implementation).
 
-The implementation looks like this:
+Let's generate the workflow class to be able to work on it using the corresponding artisan command:
+
+```sh
+php artisan zenaton:make:workflow MyFirstWorkflow
+```
+
+Open the `app/Zenaton/Workflows/MyFirstWorkflow.php` file that was generated for you
+and implement the `::handle()` method as the following:
 
 ```php
 namespace App\Zenaton\Workflows;

--- a/src/Console/Commands/MakeTaskCommand.php
+++ b/src/Console/Commands/MakeTaskCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zenaton\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+final class MakeTaskCommand extends GeneratorCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $signature = 'zenaton:make:task {name : The name of the task}';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Create a new task class';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $type = 'Task class';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/stubs/task.stub';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Zenaton\Tasks';
+    }
+}

--- a/src/Console/Commands/MakeWorkflowCommand.php
+++ b/src/Console/Commands/MakeWorkflowCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Zenaton\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+final class MakeWorkflowCommand extends GeneratorCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $signature = 'zenaton:make:workflow {name : The name of the workflow}';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Create a new workflow class';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $type = 'Workflow class';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/stubs/workflow.stub';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Zenaton\Workflows';
+    }
+}

--- a/src/Console/Commands/stubs/task.stub
+++ b/src/Console/Commands/stubs/task.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace DummyNamespace;
+
+use Zenaton\Interfaces\TaskInterface;
+use Zenaton\Traits\Zenatonable;
+
+class DummyClass implements TaskInterface
+{
+    use Zenatonable;
+
+    public function handle()
+    {
+    }
+}

--- a/src/Console/Commands/stubs/workflow.stub
+++ b/src/Console/Commands/stubs/workflow.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace DummyNamespace;
+
+use Zenaton\Interfaces\WorkflowInterface;
+use Zenaton\Traits\Zenatonable;
+
+class DummyClass implements WorkflowInterface
+{
+    use Zenatonable;
+
+    public function handle()
+    {
+    }
+}

--- a/src/ZenatonServiceProvider.php
+++ b/src/ZenatonServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Zenaton;
 
 use Illuminate\Support\ServiceProvider;
+use Zenaton\Console\Commands\MakeTaskCommand;
+use Zenaton\Console\Commands\MakeWorkflowCommand;
 
 class ZenatonServiceProvider extends ServiceProvider
 {
@@ -12,6 +14,7 @@ class ZenatonServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPublishing();
+        $this->registerCommands();
 
         Client::init(
             config('zenaton.app_id'),
@@ -21,7 +24,24 @@ class ZenatonServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register artisan commands.
+     *
+     * @return void
+     */
+    private function registerCommands()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                MakeTaskCommand::class,
+                MakeWorkflowCommand::class,
+            ]);
+        }
+    }
+
+    /**
      * Register the package's publishable resources.
+     *
+     * @return void
      */
     private function registerPublishing()
     {


### PR DESCRIPTION
This adds the ability to generate workflows and tasks classes using an artisan command:

```sh
php artisan zenaton:make:workflow ComputeUsageMetricsWorkflow
```

```sh
php artisan zenaton:make:task GetUsageMetricsTask
```

Closes #1 